### PR TITLE
Add `flake.nix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,66 @@ For syntax and other topics, see the [modularcalculator wiki](https://github.com
 
 There is a flatpak available on [Flathub](https://flathub.org/apps/details/io.github.jordanl2.ModularCalculator).
 
+## Nix
+
+There is a community maintained Nix flake available in this repository. This flake can be used to run or install the program on NixOS or other distributions.
+
+Run the program once without installing:
+
+```bash
+nix run --no-write-lock-file github:JordanL2/ModularCalculatorInterface
+```
+
+Install the program:
+
+```bash
+nix profile add --no-write-lock-file github:JordanL2/ModularCalculatorInterface
+```
+
+Add to system configuration (NixOS only):
+
+```nix
+# In flake.nix
+{
+  inputs = {
+    modularcalculator.url = "github:JordanL2/ModularCalculatorInterface";
+  };
+
+  outputs = { modularcalculator, ... }: {
+    nixosConfigurations.<host> = nixpkgs.lib.nixosSystem {
+      modules = [
+        ./configuration.nix
+      ];
+      specialArgs = {
+        inherit modularcalculator;
+      };
+    };
+  };
+}
+
+# in configuration.nix
+{ modularcalculator, ... }:
+{
+    environment.systemPackages = [
+        modularcalculator.packages.x86_64-linux.default
+    ];
+}
+```
+
+Install python library (NixOS only):
+
+```nix
+# in configuration.nix
+{ pkgs, modularcalculator, ... }:
+{
+    environment.systemPackages = [
+        (pkgs.python3.withPackages([
+            modularcalculator.packages.x86_64-linux.python
+        ]))
+    ];
+}
+```
+
 ## Manually
 
 Clone this repository, then run:
@@ -41,6 +101,12 @@ If you download the source tarball, you'll also need to download the [modularcal
 
 
 # Uninstallation
+
+## Nix
+
+```bash
+nix profile remove ModularCalculatorInterface
+```
 
 ## Manually
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,124 @@
+{
+  description = "A module to install modular calculator interface.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";  # Keep this updated to latest stable
+  };
+
+  outputs = { self, nixpkgs, ... }:
+  let
+    pkgs = import nixpkgs {
+      system = "x86_64-linux";
+    };
+    lib = pkgs.lib;
+    modularcalculator = pkgs.python3Packages.buildPythonPackage rec {
+        pname = "modularcalculator";
+        version = "1.5.0";  # Update this when a new version is released
+        pyproject = true;
+
+        src = pkgs.fetchFromGitHub {
+            owner = "JordanL2";
+            repo = "ModularCalculator";
+            tag = version;
+            sha256 = "1zzik9mz87637m54hb8x0nxs7fhiij4q9d8bvvr8l74cc1ankf3j";
+            # Use the following command to get the sha256 hash when updating:
+            # nix-prefetch-url --unpack https://github.com/JordanL2/ModularCalculator/archive/refs/tags/<version>.tar.gz
+        };
+        
+        nativeBuildInputs = with pkgs.python3Packages; [
+            setuptools
+        ];
+        
+        dependencies = with pkgs.python3Packages; [
+            pyyaml
+            scipy
+            strct
+        ];
+        
+        postPatch = ''
+            sed -i 's/unittest.main(exit=False)/unittest.main(exit=True)/g' tests/testrunner.py
+        '';
+        
+        #checkPhase = ''
+        #  PYTHONPATH=$PYTHONPATH:$PWD ${pkgs.python3.interpreter} tests/tests.py
+        #'';
+        
+        meta = {
+            description = "Powerful modular calculator engine";
+            homepage = "https://github.com/JordanL2/ModularCalculator";
+            license = lib.licenses.asl20;
+            maintainers = with lib.maintainers; [ Tommimon ];
+        };
+    };
+  in
+  {
+    packages.x86_64-linux = {
+        python = modularcalculator;
+        default = pkgs.python3Packages.buildPythonApplication rec {
+            pname = "modularcalculator-qt";
+            version = "1.5.6";  # Update this when a new version is released
+            pyproject = true;
+
+            src = pkgs.fetchFromGitHub {
+                owner = "JordanL2";
+                repo = "ModularCalculatorInterface";
+                tag = version;
+                sha256 = "11rjnwknh12mgjv5vkyxa1kvw57z6akyh3jz4rmb6gh31kl3hxlm";
+                # Use the following command to get the sha256 hash when updating:
+                # nix-prefetch-url --unpack https://github.com/JordanL2/ModularCalculatorInterface/archive/refs/tags/<version>.tar.gz
+            };
+
+            buildInputs = [ pkgs.qt6.qtwayland ];
+
+            nativeBuildInputs = with pkgs; [
+                copyDesktopItems
+                modularcalculator
+                python3Packages.hatchling
+                python3Packages.hatch-vcs
+                python3Packages.pyyaml
+                python3Packages.scipy
+                qt6.wrapQtAppsHook
+            ];
+
+            propagatedBuildInputs = with pkgs.python3Packages; [
+                darkdetect
+                modularcalculator
+                pillow
+                platformdirs
+                pyqrcode
+                pyqt6
+                python-barcode
+                pyusb
+                pyyaml
+                rich
+                scipy
+                typer
+            ];
+
+            desktopItems = [
+                (pkgs.makeDesktopItem {
+                name = "Modular Calculator";
+                exec = "modularcalculator";
+                desktopName = "Modular Calculator";
+                icon = "modularcalculator-qt";
+                })
+            ];
+
+            postInstall = ''
+                cp -r $src/config $out/config
+                for size in 16 24 48 64 128 256; do
+                install -Dm644 $src/icons/''${size}x''${size}.png $out/share/icons/hicolor/''${size}x''${size}/apps/modularcalculator-qt.png || true
+                done
+            '';
+
+            meta = {
+                description = "A powerful, scriptable, modular calculator aimed at scientific, engineering or computing work.";
+                homepage = "https://github.com/JordanL2/ModularCalculatorInterface";
+                license = lib.licenses.asl20;
+                maintainers = with lib.maintainers; [ Tommimon ];
+                mainProgram = "modularcalculator";
+            };
+        };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -59,14 +59,7 @@
             version = "1.5.6";  # Update this when a new version is released
             pyproject = true;
 
-            src = pkgs.fetchFromGitHub {
-                owner = "JordanL2";
-                repo = "ModularCalculatorInterface";
-                tag = version;
-                sha256 = "11rjnwknh12mgjv5vkyxa1kvw57z6akyh3jz4rmb6gh31kl3hxlm";
-                # Use the following command to get the sha256 hash when updating:
-                # nix-prefetch-url --unpack https://github.com/JordanL2/ModularCalculatorInterface/archive/refs/tags/<version>.tar.gz
-            };
+            src = ./.;
 
             buildInputs = [ pkgs.qt6.qtwayland ];
 


### PR DESCRIPTION
I ported `modularcalculator` to NixOS and used it for a while with no issues.

I would like to upstream the Nix flake that I'm using to enable other people using Nix to install it. Note that the Nix package manager can be installed on any Linux distribution, so this is not only for people using NixOS.

I also updated the README.md with the instructions to install with Nix.